### PR TITLE
add the alias field in findinstancesrequest

### DIFF
--- a/discovery/instance.go
+++ b/discovery/instance.go
@@ -40,6 +40,7 @@ type FindInstancesRequest struct {
 	VersionRule       string   `protobuf:"bytes,4,opt,name=versionRule" json:"versionRule,omitempty"`
 	Tags              []string `protobuf:"bytes,5,rep,name=tags" json:"tags,omitempty"`
 	Environment       string   `protobuf:"bytes,6,opt,name=environment" json:"environment,omitempty"`
+	Alias             string   `protobuf:"bytes,7,opt,name=alias" json:"alias,omitempty"`
 }
 type FindInstancesResponse struct {
 	Response  *Response               `protobuf:"bytes,1,opt,name=response" json:"response,omitempty"`


### PR DESCRIPTION
**fix bug**:  When I examine the use case, I find that the query alias condition of findingstance interface uses servicename. The alias field should be added.

![image](https://user-images.githubusercontent.com/27326092/104160719-8add8680-542c-11eb-9590-932bf185e463.png)
