### PR TITLE
fix: add ErrWebsocketInstanceNotExists for websocket disconnection

### DIFF
--- a/discovery/error.go
+++ b/discovery/error.go
@@ -20,6 +20,11 @@ package discovery
 import "github.com/go-chassis/cari/pkg/errsvc"
 
 const (
+	// ErrWebsocketInstanceNotExists custom error is used to end the websocket disconnection
+	ErrWebsocketInstanceNotExists int = 4001
+)
+
+const (
 	ErrInvalidParams           int32 = 400001
 	ErrUnhealthy               int32 = 400002
 	ErrServiceAlreadyExists    int32 = 400010


### PR DESCRIPTION
What type of PR is this?
/fix

What this PR does / why we need it:
add WebsocketErrInstanceNotExists for websocket disconnection

Which issue(s) this PR fixes:
Fixes https://github.com/go-chassis/sc-client/pull/46

Special notes for your reviewer: @tianxiaoliang @little-cui

Use case description:

No

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No
