### PR TITLE
add domain and project field to task struct in sync

### DIFF
--- a/sync/types.go
+++ b/sync/types.go
@@ -28,6 +28,8 @@ type Task struct {
 	TaskID    string      `json:"task_id" bson:"task_id"`
 	Action    string      `json:"action" bson:"action"`
 	DataType  string      `json:"data_type" bson:"data_type"`
+	Domain    string      `json:"domain" bson:"domain"`
+	Project   string      `json:"project" bson:"project"`
 	Data      interface{} `json:"data" bson:"data"`
 	Timestamp int64       `json:"timestamp" bson:"timestamp"`
 	Status    string      `json:"status" bson:"status"`


### PR DESCRIPTION
What type of PR is this?

/fix

What this PR does / why we need it:

Add domain and project field to task struct in sync. Using mongo to query tasks requires the use of domain, project and taskid to ensure uniqueness


Special notes for your reviewer: @tianxiaoliang @little-cui

Use case description: No

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No