### PR TITLE
[fix] use string and []byte to store resource

### DIFF
--- a/discovery/types.go
+++ b/discovery/types.go
@@ -17,7 +17,9 @@
 
 package discovery
 
-import "fmt"
+import (
+	"fmt"
+)
 
 const (
 	MS_UP   string = "UP"

--- a/sync/task.go
+++ b/sync/task.go
@@ -18,6 +18,7 @@
 package sync
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -28,19 +29,24 @@ const (
 	DoneStatus    = "done"
 )
 
-// NewTask return task with action and datatype
-func NewTask(domain, project, action, dataType string) (*Task, error) {
+// NewTask return task with domain, project , action , resourceType and resource
+func NewTask(domain, project, action, resourceType string, resource interface{}) (*Task, error) {
 	taskId, err := uuid.NewV4()
 	if err != nil {
 		return nil, err
 	}
+	resourceValue, err := json.Marshal(resource)
+	if err != nil {
+		return nil, err
+	}
 	return &Task{
-		TaskID:    taskId.String(),
-		Action:    action,
-		DataType:  dataType,
-		Domain:    domain,
-		Project:   project,
-		Timestamp: time.Now().UnixNano(),
-		Status:    PendingStatus,
+		ID:           taskId.String(),
+		Domain:       domain,
+		Project:      project,
+		ResourceType: resourceType,
+		Resource:     resourceValue,
+		Action:       action,
+		Timestamp:    time.Now().UnixNano(),
+		Status:       PendingStatus,
 	}, nil
 }

--- a/sync/types.go
+++ b/sync/types.go
@@ -25,14 +25,14 @@ const (
 
 // Task is db struct to store sync task
 type Task struct {
-	TaskID    string      `json:"task_id" bson:"task_id"`
-	Action    string      `json:"action" bson:"action"`
-	DataType  string      `json:"data_type" bson:"data_type"`
-	Domain    string      `json:"domain" bson:"domain"`
-	Project   string      `json:"project" bson:"project"`
-	Data      interface{} `json:"data" bson:"data"`
-	Timestamp int64       `json:"timestamp" bson:"timestamp"`
-	Status    string      `json:"status" bson:"status"`
+	ID           string `json:"id" bson:"id"`
+	Domain       string `json:"domain" bson:"domain"`
+	Project      string `json:"project" bson:"project"`
+	ResourceType string `json:"resource_type" bson:"resource_type"`
+	Resource     []byte `json:"resource" bson:"resource"`
+	Action       string `json:"action" bson:"action"`
+	Timestamp    int64  `json:"timestamp" bson:"timestamp"`
+	Status       string `json:"status" bson:"status"`
 }
 
 // Tombstone is db struct to store the deleted resource information


### PR DESCRIPTION
【issue】：#47
【修改内容】：
1、将原先 task 中的datatype和data修改成resource和resourceType，将原先的 interface 修改成[]byte
2、抽象resource 的接口里面有两个func，分别用于获取资源类型和其marshal后的值
3、将service、schema、account、role都实现了上诉的 resource 接口
4、修改了task中的task_id字段为id（因为task有点多余），还有就是换了下 task 中几个字段的位置，按重要性拍了个序
【修改原因】：因为struct里面含有interface，marshal后再unmarshal回来，相应的结构体无法解析，有好几种解决方案。还是转换为[]byte，后unmarshal后再次unmarshal对应的资源类型就可以了
【影响范围】：无