### PR TITLE
[fix] when domain or project is empty should return default

### DIFF
--- a/sync/task.go
+++ b/sync/task.go
@@ -35,6 +35,12 @@ func NewTask(domain, project, action, resourceType string, resource interface{})
 	if err != nil {
 		return nil, err
 	}
+	if len(domain) == 0 {
+		domain = Default
+	}
+	if len(project) == 0 {
+		project = Default
+	}
 
 	var resourceValue []byte
 	switch rv := resource.(type) {

--- a/sync/task_test.go
+++ b/sync/task_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sync
 
 import (
@@ -12,6 +29,15 @@ func TestNewTask(t *testing.T) {
 		task, err := NewTask("", "", "", "", "hello")
 		if assert.Nil(t, err) {
 			assert.Equal(t, []byte("hello"), task.Resource)
+		}
+	})
+
+	t.Run("resource is string, domain and project is empty, domain and project should return default", func(t *testing.T) {
+		task, err := NewTask("", "", "", "", "hello")
+		if assert.Nil(t, err) {
+			assert.Equal(t, []byte("hello"), task.Resource)
+			assert.Equal(t, Default, task.Domain)
+			assert.Equal(t, Default, task.Project)
 		}
 	})
 

--- a/sync/tombstone_test.go
+++ b/sync/tombstone_test.go
@@ -17,21 +17,16 @@
 
 package sync
 
-import "time"
+import (
+	"testing"
 
-// NewTombstone return tombstone with resourceID,resourceType ,domain and project
-func NewTombstone(domain, project, resourceType, resourceID string) *Tombstone {
-	if len(domain) == 0 {
-		domain = Default
-	}
-	if len(project) == 0 {
-		project = Default
-	}
-	return &Tombstone{
-		ResourceID:   resourceID,
-		ResourceType: resourceType,
-		Domain:       domain,
-		Project:      project,
-		Timestamp:    time.Now().UnixNano(),
-	}
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTombstone(t *testing.T) {
+	t.Run("create a tombstone, the domain and project is empty should return default", func(t *testing.T) {
+		tombstone := NewTombstone("", "", "kv", "11111")
+		assert.Equal(t, Default, tombstone.Domain)
+		assert.Equal(t, Default, tombstone.Project)
+	})
 }

--- a/sync/types.go
+++ b/sync/types.go
@@ -21,6 +21,8 @@ const (
 	CreateAction = "create"
 	UpdateAction = "update"
 	DeleteAction = "delete"
+
+	Default = "default"
 )
 
 // Task is db struct to store sync task


### PR DESCRIPTION
【修改说明】当 domain 或 project 都为空的时候，应该返回 default
【修改内容】再创建 task 和 tombstone 的时候做对 domain 和 project 的判断，如果为空则赋值为 default
【测试用例】添加空值判断的测试用例
